### PR TITLE
Commented ZipInputStream Usage

### DIFF
--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieTest.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieTest.kt
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileInputStream
 import java.util.concurrent.TimeUnit
-import java.util.zip.ZipInputStream
 import com.airbnb.lottie.samples.R as SampleAppR
 
 /**
@@ -138,8 +137,8 @@ class LottieTest {
     ) {
         for (file in files) {
             log("Parsing ${file.nameWithoutExtension}")
-            val result = if (file.name.endsWith("zip")) LottieCompositionFactory.fromZipStreamSync(ZipInputStream(FileInputStream(file)), file.name)
-            else LottieCompositionFactory.fromJsonInputStreamSync(FileInputStream(file), file.name)
+            // val result = if (file.name.endsWith("zip")) LottieCompositionFactory.fromZipStreamSync(ZipInputStream(FileInputStream(file)), file.name) else LottieCompositionFactory.fromJsonInputStreamSync(FileInputStream(file), file.name)
+            val result = LottieCompositionFactory.fromJsonInputStreamSync(FileInputStream(file), file.name)
             val composition = result.value
                     ?: throw IllegalStateException("Unable to parse ${file.nameWithoutExtension}")
             send("prod-${file.nameWithoutExtension}" to composition)

--- a/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieTest.kt
+++ b/LottieSample/src/androidTest/java/com/airbnb/lottie/LottieTest.kt
@@ -24,7 +24,6 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.mobileconnectors.s3.transferutility.TransferUtility
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.S3ObjectSummary
-import junit.framework.Assert.assertNull
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
@@ -137,7 +136,6 @@ class LottieTest {
     ) {
         for (file in files) {
             log("Parsing ${file.nameWithoutExtension}")
-            // val result = if (file.name.endsWith("zip")) LottieCompositionFactory.fromZipStreamSync(ZipInputStream(FileInputStream(file)), file.name) else LottieCompositionFactory.fromJsonInputStreamSync(FileInputStream(file), file.name)
             val result = LottieCompositionFactory.fromJsonInputStreamSync(FileInputStream(file), file.name)
             val composition = result.value
                     ?: throw IllegalStateException("Unable to parse ${file.nameWithoutExtension}")

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
@@ -88,7 +87,6 @@ public class LottieCompositionFactory {
    * The asset file name will be used as a cache key so future usages won't have to parse the json again.
    * However, if your animation has images, you may package the json and images as a single flattened zip file in assets.
    *
-   * @see #fromZipStream(ZipInputStream, String)
    */
   public static LottieTask<LottieComposition> fromAsset(Context context, final String fileName) {
     // Prevent accidentally leaking an Activity.
@@ -106,14 +104,13 @@ public class LottieCompositionFactory {
    * The asset file name will be used as a cache key so future usages won't have to parse the json again.
    * However, if your animation has images, you may package the json and images as a single flattened zip file in assets.
    *
-   * @see #fromZipStreamSync(ZipInputStream, String)
    */
   @WorkerThread
   public static LottieResult<LottieComposition> fromAssetSync(Context context, String fileName) {
     try {
       String cacheKey = "asset_" + fileName;
       if (fileName.endsWith(".zip")) {
-        return fromZipStreamSync(new ZipInputStream(context.getAssets().open(fileName)), cacheKey);
+        // return fromZipStreamSync(new ZipInputStream(context.getAssets().open(fileName)), cacheKey);
       }
       return fromJsonInputStreamSync(context.getAssets().open(fileName), cacheKey);
     } catch (IOException e) {
@@ -272,79 +269,79 @@ public class LottieCompositionFactory {
   }
 
 
-  public static LottieTask<LottieComposition> fromZipStream(final ZipInputStream inputStream, @Nullable final String cacheKey) {
-    return cache(cacheKey, new Callable<LottieResult<LottieComposition>>() {
-      @Override
-      public LottieResult<LottieComposition> call() {
-        return fromZipStreamSync(inputStream, cacheKey);
-      }
-    });
-  }
+  // public static LottieTask<LottieComposition> fromZipStream(final ZipInputStream inputStream, @Nullable final String cacheKey) {
+  //   return cache(cacheKey, new Callable<LottieResult<LottieComposition>>() {
+  //     @Override
+  //     public LottieResult<LottieComposition> call() {
+  //       return fromZipStreamSync(inputStream, cacheKey);
+  //     }
+  //   });
+  // }
 
   /**
    * Parses a zip input stream into a Lottie composition.
    * Your zip file should just be a folder with your json file and images zipped together.
    * It will automatically store and configure any images inside the animation if they exist.
    */
-  @WorkerThread
-  public static LottieResult<LottieComposition> fromZipStreamSync(ZipInputStream inputStream, @Nullable String cacheKey) {
-    try {
-      return fromZipStreamSyncInternal(inputStream, cacheKey);
-    } finally {
-      closeQuietly(inputStream);
-    }
-  }
+  // @WorkerThread
+  // public static LottieResult<LottieComposition> fromZipStreamSync(ZipInputStream inputStream, @Nullable String cacheKey) {
+  //   try {
+  //     return fromZipStreamSyncInternal(inputStream, cacheKey);
+  //   } finally {
+  //     closeQuietly(inputStream);
+  //   }
+  // }
 
-  @WorkerThread
-  private static LottieResult<LottieComposition> fromZipStreamSyncInternal(ZipInputStream inputStream, @Nullable String cacheKey) {
-    LottieComposition composition = null;
-    Map<String, Bitmap> images = new HashMap<>();
-
-    try {
-      ZipEntry entry = inputStream.getNextEntry();
-      while (entry != null) {
-        final String entryName = entry.getName();
-        if (entryName.contains("__MACOSX")) {
-          inputStream.closeEntry();
-        } else if (entry.getName().contains(".json")) {
-          com.airbnb.lottie.parser.moshi.JsonReader reader = of(buffer(source(inputStream)));
-          composition = LottieCompositionFactory.fromJsonReaderSyncInternal(reader, null, false).getValue();
-        } else if (entryName.contains(".png") || entryName.contains(".webp")) {
-          String[] splitName = entryName.split("/");
-          String name = splitName[splitName.length - 1];
-          images.put(name, BitmapFactory.decodeStream(inputStream));
-        } else {
-          inputStream.closeEntry();
-        }
-
-        entry = inputStream.getNextEntry();
-      }
-    } catch (IOException e) {
-      return new LottieResult<>(e);
-    }
-
-
-    if (composition == null) {
-      return new LottieResult<>(new IllegalArgumentException("Unable to parse composition"));
-    }
-
-    for (Map.Entry<String, Bitmap> e : images.entrySet()) {
-      LottieImageAsset imageAsset = findImageAssetForFileName(composition, e.getKey());
-      if (imageAsset != null) {
-        imageAsset.setBitmap(Utils.resizeBitmapIfNeeded(e.getValue(), imageAsset.getWidth(), imageAsset.getHeight()));
-      }
-    }
-
-    // Ensure that all bitmaps have been set.
-    for (Map.Entry<String, LottieImageAsset> entry : composition.getImages().entrySet()) {
-      if (entry.getValue().getBitmap() == null) {
-        return new LottieResult<>(new IllegalStateException("There is no image for " + entry.getValue().getFileName()));
-      }
-    }
-
-    LottieCompositionCache.getInstance().put(cacheKey, composition);
-    return new LottieResult<>(composition);
-  }
+  // @WorkerThread
+  // private static LottieResult<LottieComposition> fromZipStreamSyncInternal(ZipInputStream inputStream, @Nullable String cacheKey) {
+  //   LottieComposition composition = null;
+  //   Map<String, Bitmap> images = new HashMap<>();
+  //
+  //   try {
+  //     ZipEntry entry = inputStream.getNextEntry();
+  //     while (entry != null) {
+  //       final String entryName = entry.getName();
+  //       if (entryName.contains("__MACOSX")) {
+  //         inputStream.closeEntry();
+  //       } else if (entry.getName().contains(".json")) {
+  //         com.airbnb.lottie.parser.moshi.JsonReader reader = of(buffer(source(inputStream)));
+  //         composition = LottieCompositionFactory.fromJsonReaderSyncInternal(reader, null, false).getValue();
+  //       } else if (entryName.contains(".png") || entryName.contains(".webp")) {
+  //         String[] splitName = entryName.split("/");
+  //         String name = splitName[splitName.length - 1];
+  //         images.put(name, BitmapFactory.decodeStream(inputStream));
+  //       } else {
+  //         inputStream.closeEntry();
+  //       }
+  //
+  //       entry = inputStream.getNextEntry();
+  //     }
+  //   } catch (IOException e) {
+  //     return new LottieResult<>(e);
+  //   }
+  //
+  //
+  //   if (composition == null) {
+  //     return new LottieResult<>(new IllegalArgumentException("Unable to parse composition"));
+  //   }
+  //
+  //   for (Map.Entry<String, Bitmap> e : images.entrySet()) {
+  //     LottieImageAsset imageAsset = findImageAssetForFileName(composition, e.getKey());
+  //     if (imageAsset != null) {
+  //       imageAsset.setBitmap(Utils.resizeBitmapIfNeeded(e.getValue(), imageAsset.getWidth(), imageAsset.getHeight()));
+  //     }
+  //   }
+  //
+  //   // Ensure that all bitmaps have been set.
+  //   for (Map.Entry<String, LottieImageAsset> entry : composition.getImages().entrySet()) {
+  //     if (entry.getValue().getBitmap() == null) {
+  //       return new LottieResult<>(new IllegalStateException("There is no image for " + entry.getValue().getFileName()));
+  //     }
+  //   }
+  //
+  //   LottieCompositionCache.getInstance().put(cacheKey, composition);
+  //   return new LottieResult<>(composition);
+  // }
 
   @Nullable
   private static LottieImageAsset findImageAssetForFileName(LottieComposition composition, String fileName) {

--- a/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
+++ b/lottie/src/main/java/com/airbnb/lottie/LottieCompositionFactory.java
@@ -2,15 +2,12 @@ package com.airbnb.lottie;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 
 import com.airbnb.lottie.model.LottieCompositionCache;
 import com.airbnb.lottie.network.NetworkFetcher;
 import com.airbnb.lottie.parser.LottieCompositionMoshiParser;
 import com.airbnb.lottie.parser.moshi.JsonReader;
 
-import com.airbnb.lottie.utils.Utils;
 import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
@@ -19,7 +16,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.zip.ZipEntry;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
@@ -110,7 +106,7 @@ public class LottieCompositionFactory {
     try {
       String cacheKey = "asset_" + fileName;
       if (fileName.endsWith(".zip")) {
-        // return fromZipStreamSync(new ZipInputStream(context.getAssets().open(fileName)), cacheKey);
+        return null;
       }
       return fromJsonInputStreamSync(context.getAssets().open(fileName), cacheKey);
     } catch (IOException e) {
@@ -267,81 +263,6 @@ public class LottieCompositionFactory {
       }
     }
   }
-
-
-  // public static LottieTask<LottieComposition> fromZipStream(final ZipInputStream inputStream, @Nullable final String cacheKey) {
-  //   return cache(cacheKey, new Callable<LottieResult<LottieComposition>>() {
-  //     @Override
-  //     public LottieResult<LottieComposition> call() {
-  //       return fromZipStreamSync(inputStream, cacheKey);
-  //     }
-  //   });
-  // }
-
-  /**
-   * Parses a zip input stream into a Lottie composition.
-   * Your zip file should just be a folder with your json file and images zipped together.
-   * It will automatically store and configure any images inside the animation if they exist.
-   */
-  // @WorkerThread
-  // public static LottieResult<LottieComposition> fromZipStreamSync(ZipInputStream inputStream, @Nullable String cacheKey) {
-  //   try {
-  //     return fromZipStreamSyncInternal(inputStream, cacheKey);
-  //   } finally {
-  //     closeQuietly(inputStream);
-  //   }
-  // }
-
-  // @WorkerThread
-  // private static LottieResult<LottieComposition> fromZipStreamSyncInternal(ZipInputStream inputStream, @Nullable String cacheKey) {
-  //   LottieComposition composition = null;
-  //   Map<String, Bitmap> images = new HashMap<>();
-  //
-  //   try {
-  //     ZipEntry entry = inputStream.getNextEntry();
-  //     while (entry != null) {
-  //       final String entryName = entry.getName();
-  //       if (entryName.contains("__MACOSX")) {
-  //         inputStream.closeEntry();
-  //       } else if (entry.getName().contains(".json")) {
-  //         com.airbnb.lottie.parser.moshi.JsonReader reader = of(buffer(source(inputStream)));
-  //         composition = LottieCompositionFactory.fromJsonReaderSyncInternal(reader, null, false).getValue();
-  //       } else if (entryName.contains(".png") || entryName.contains(".webp")) {
-  //         String[] splitName = entryName.split("/");
-  //         String name = splitName[splitName.length - 1];
-  //         images.put(name, BitmapFactory.decodeStream(inputStream));
-  //       } else {
-  //         inputStream.closeEntry();
-  //       }
-  //
-  //       entry = inputStream.getNextEntry();
-  //     }
-  //   } catch (IOException e) {
-  //     return new LottieResult<>(e);
-  //   }
-  //
-  //
-  //   if (composition == null) {
-  //     return new LottieResult<>(new IllegalArgumentException("Unable to parse composition"));
-  //   }
-  //
-  //   for (Map.Entry<String, Bitmap> e : images.entrySet()) {
-  //     LottieImageAsset imageAsset = findImageAssetForFileName(composition, e.getKey());
-  //     if (imageAsset != null) {
-  //       imageAsset.setBitmap(Utils.resizeBitmapIfNeeded(e.getValue(), imageAsset.getWidth(), imageAsset.getHeight()));
-  //     }
-  //   }
-  //
-  //   // Ensure that all bitmaps have been set.
-  //   for (Map.Entry<String, LottieImageAsset> entry : composition.getImages().entrySet()) {
-  //     if (entry.getValue().getBitmap() == null) {
-  //       return new LottieResult<>(new IllegalStateException("There is no image for " + entry.getValue().getFileName()));
-  //     }
-  //   }
-  //
-  //   LottieCompositionCache.getInstance().put(cacheKey, composition);
-  //   return new LottieResult<>(composition);
-  // }
 
   @Nullable
   private static LottieImageAsset findImageAssetForFileName(LottieComposition composition, String fileName) {

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.zip.ZipInputStream;
 
 public class NetworkFetcher {
 
@@ -63,7 +62,8 @@ public class NetworkFetcher {
     InputStream inputStream = cacheResult.second;
     LottieResult<LottieComposition> result;
     if (extension == FileExtension.ZIP) {
-      result = LottieCompositionFactory.fromZipStreamSync(new ZipInputStream(inputStream), url);
+      // result = LottieCompositionFactory.fromZipStreamSync(new ZipInputStream(inputStream), url);
+      return null;
     } else {
       result = LottieCompositionFactory.fromJsonInputStreamSync(inputStream, url);
     }
@@ -146,7 +146,7 @@ public class NetworkFetcher {
         Logger.debug("Handling zip response.");
         extension = FileExtension.ZIP;
         file = networkCache.writeTempCacheFile(connection.getInputStream(), extension);
-        result = LottieCompositionFactory.fromZipStreamSync(new ZipInputStream(new FileInputStream(file)), url);
+        // result = LottieCompositionFactory.fromZipStreamSync(new ZipInputStream(new FileInputStream(file)), url);
         break;
       case "application/json":
       default:

--- a/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
+++ b/lottie/src/main/java/com/airbnb/lottie/network/NetworkFetcher.java
@@ -62,7 +62,6 @@ public class NetworkFetcher {
     InputStream inputStream = cacheResult.second;
     LottieResult<LottieComposition> result;
     if (extension == FileExtension.ZIP) {
-      // result = LottieCompositionFactory.fromZipStreamSync(new ZipInputStream(inputStream), url);
       return null;
     } else {
       result = LottieCompositionFactory.fromJsonInputStreamSync(inputStream, url);
@@ -145,8 +144,6 @@ public class NetworkFetcher {
       case "application/zip":
         Logger.debug("Handling zip response.");
         extension = FileExtension.ZIP;
-        file = networkCache.writeTempCacheFile(connection.getInputStream(), extension);
-        // result = LottieCompositionFactory.fromZipStreamSync(new ZipInputStream(new FileInputStream(file)), url);
         break;
       case "application/json":
       default:


### PR DESCRIPTION
## 📖 Description et motivation

Enlever toute utilisation de ZipInputStream dans le projet Forké de Lottie-Android.

## 👷 Travail effectué

* Commenter les occurences de ZipInputStream
* Return null dans le cas où on pouvait
* Commenter les fonctions prenant en paramètres ZipInputStream

#### Notes additionnelles

Le projet build bien. Mais il y a risque de crash si on utilise la feature de zip éventuellement